### PR TITLE
Fix crash when parsing addrinfo

### DIFF
--- a/Sources/WireGuardKit/IPAddress+AddrInfo.swift
+++ b/Sources/WireGuardKit/IPAddress+AddrInfo.swift
@@ -8,7 +8,10 @@ extension IPv4Address {
     init?(addrInfo: addrinfo) {
         guard addrInfo.ai_family == AF_INET else { return nil }
 
-        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: MemoryLayout<sockaddr_in>.size) { ptr -> Data in
+        let addressData = addrInfo.ai_addr.withMemoryRebound(
+            to: sockaddr_in.self,
+            capacity: 1
+        ) { ptr -> Data in
             return Data(bytes: &ptr.pointee.sin_addr, count: MemoryLayout<in_addr>.size)
         }
 
@@ -20,7 +23,10 @@ extension IPv6Address {
     init?(addrInfo: addrinfo) {
         guard addrInfo.ai_family == AF_INET6 else { return nil }
 
-        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in6.self, capacity: MemoryLayout<sockaddr_in6>.size) { ptr -> Data in
+        let addressData = addrInfo.ai_addr.withMemoryRebound(
+            to: sockaddr_in6.self,
+            capacity: 1
+        ) { ptr -> Data in
             return Data(bytes: &ptr.pointee.sin6_addr, count: MemoryLayout<in6_addr>.size)
         }
 


### PR DESCRIPTION
The `capacity` argument in `withMemoryRebound<T>(to: T.Type, capacity: Int, ...)` indicates the number of instances of `T` and not number of bytes within the buffer pointer. 

This PR changes the `capacity` to `1` when reading `sockaddr_in` and `sockaddr_in6` in IPv4/IPv6 initializers taking `addrinfo`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/4)
<!-- Reviewable:end -->
