### PR TITLE
Kit: implement Codable for IPAddressRange

### DIFF
--- a/Sources/WireGuardKitTypes/IPAddressRange.swift
+++ b/Sources/WireGuardKitTypes/IPAddressRange.swift
@@ -27,6 +27,29 @@ extension IPAddressRange: Hashable {
     }
 }
 
+extension IPAddressRange: Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        try container.encode(self.stringRepresentation)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+
+        if let ipAddressRange = IPAddressRange(from: value) {
+            self = ipAddressRange
+        } else {
+            let context = DecodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Invalid IPAddressRange representation"
+            )
+            throw DecodingError.dataCorrupted(context)
+        }
+    }
+}
+
 extension IPAddressRange {
     public var stringRepresentation: String {
         return "\(address)/\(networkPrefixLength)"


### PR DESCRIPTION
Move Codable implementation for `IPAddressRange` from `MullvadVPN` into `WireGuardKitTypes`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/5)
<!-- Reviewable:end -->
