### PR TITLE
Kit: replace path monitor with KVO observer on defaultPath

### DIFF
--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -48,6 +48,12 @@ public class WireGuardAdapter {
     /// Packet tunnel provider.
     private weak var packetTunnelProvider: NEPacketTunnelProvider?
 
+    /// KVO observer for `NEProvider.defaultPath`.
+    private var defaultPathObserver: NSKeyValueObservation?
+
+    /// Last known default path.
+    private var currentDefaultPath: NetworkExtension.NWPath?
+
     /// Log handler closure.
     private let logHandler: LogHandler
 
@@ -189,11 +195,7 @@ public class WireGuardAdapter {
                 return
             }
 
-            let networkMonitor = NWPathMonitor()
-            networkMonitor.pathUpdateHandler = { [weak self] path in
-                self?.didReceivePathUpdate(path: path)
-            }
-            networkMonitor.start(queue: self.workQueue)
+            self.addDefaultPathObserver()
 
             do {
                 let settingsGenerator = try self.makeSettingsGenerator(with: tunnelConfiguration)
@@ -206,10 +208,10 @@ public class WireGuardAdapter {
                     try self.startWireGuardBackend(wgConfig: wgConfig),
                     settingsGenerator
                 )
-                self.networkMonitor = networkMonitor
+
                 completionHandler(nil)
             } catch let error as WireGuardAdapterError {
-                networkMonitor.cancel()
+                self.removeDefaultPathObserver()
                 completionHandler(error)
             } catch {
                 fatalError()
@@ -233,8 +235,7 @@ public class WireGuardAdapter {
                 return
             }
 
-            self.networkMonitor?.cancel()
-            self.networkMonitor = nil
+            self.removeDefaultPathObserver()
 
             self.state = .stopped
 
@@ -447,19 +448,48 @@ public class WireGuardAdapter {
         }
     }
 
-    /// Helper method used by network path monitor.
+    private func addDefaultPathObserver() {
+        guard let packetTunnelProvider = packetTunnelProvider else { return }
+
+        defaultPathObserver?.invalidate()
+        defaultPathObserver = packetTunnelProvider.observe(\.defaultPath, options: [.new]) { [weak self] _, change in
+            guard let self = self, let defaultPath = change.newValue?.flatMap({ $0 }) else { return }
+
+            self.workQueue.async {
+                self.didReceivePathUpdate(path: defaultPath)
+            }
+        }
+
+        currentDefaultPath = packetTunnelProvider.defaultPath
+    }
+
+    private func removeDefaultPathObserver() {
+        defaultPathObserver?.invalidate()
+        defaultPathObserver = nil
+        currentDefaultPath = nil
+    }
+
+    /// Method invoked by KVO observer when new network path is received.
     /// - Parameter path: new network path
-    private func didReceivePathUpdate(path: Network.NWPath) {
-        self.logHandler(.verbose, "Network change detected with \(path.status) route and interface order \(path.availableInterfaces)")
+    private func didReceivePathUpdate(path: NetworkExtension.NWPath) {
+        let isSamePath = currentDefaultPath?.isEqual(to: path) ?? false
+
+        currentDefaultPath = path
+
+        self.logHandler(.verbose, "Network change detected with \(path.status)")
 
         #if os(macOS)
-        if case .started(let handle, _) = self.state {
+        if case .started(let handle, _) = self.state, !isSamePath {
             wgBumpSockets(handle)
         }
         #elseif os(iOS)
+        let isSatisfiable = path.status == .satisfied || path.status == .satisfiable
+
         switch self.state {
         case .started(let handle, let settingsGenerator):
-            if path.status.isSatisfiable {
+            if isSatisfiable {
+                guard !isSamePath else { return }
+
                 let (wgConfig, resolutionResults) = settingsGenerator.endpointUapiConfiguration()
                 self.logEndpointResolutionResults(resolutionResults)
 
@@ -474,7 +504,7 @@ public class WireGuardAdapter {
             }
 
         case .temporaryShutdown(let settingsGenerator):
-            guard path.status.isSatisfiable else { return }
+            guard isSatisfiable else { return }
 
             self.logHandler(.verbose, "Connectivity online, resuming backend.")
 
@@ -508,16 +538,19 @@ public enum WireGuardLogLevel: Int32 {
     case error = 1
 }
 
-private extension Network.NWPath.Status {
-    /// Returns `true` if the path is potentially satisfiable.
-    var isSatisfiable: Bool {
+extension NetworkExtension.NWPathStatus: CustomDebugStringConvertible {
+    public var debugDescription: String {
         switch self {
-        case .requiresConnection, .satisfied:
-            return true
         case .unsatisfied:
-            return false
+            return "unsatisfied"
+        case .satisfied:
+            return "satisfied"
+        case .satisfiable:
+            return "satisfiable"
+        case .invalid:
+            return "invalid"
         @unknown default:
-            return true
+            return "unknown (rawValue = \(rawValue))"
         }
     }
 }

--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -350,26 +350,29 @@ public class WireGuardAdapter {
     /// - Returns: `PacketTunnelSettingsGenerator`.
     private func setNetworkSettings(_ networkSettings: NEPacketTunnelNetworkSettings) throws {
         var systemError: Error?
-        let condition = NSCondition()
 
-        // Activate the condition
-        condition.lock()
-        defer { condition.unlock() }
+        let dispatchGroup = DispatchGroup()
+
+        dispatchGroup.enter()
 
         self.packetTunnelProvider?.setTunnelNetworkSettings(networkSettings) { error in
             systemError = error
-            condition.signal()
+            dispatchGroup.leave()
         }
 
         // Packet tunnel's `setTunnelNetworkSettings` times out in certain
         // scenarios & never calls the given callback.
-        let setTunnelNetworkSettingsTimeout: TimeInterval = 5 // seconds
+        let setTunnelNetworkSettingsTimeout: Int = 5 // seconds
 
-        if condition.wait(until: Date().addingTimeInterval(setTunnelNetworkSettingsTimeout)) {
+        let waitResult = dispatchGroup.wait(wallTimeout: .now() + .seconds(setTunnelNetworkSettingsTimeout))
+
+        switch waitResult {
+        case .success:
             if let systemError = systemError {
                 throw WireGuardAdapterError.setNetworkSettings(systemError)
             }
-        } else {
+
+        case .timedOut:
             self.logHandler(.error, "setTunnelNetworkSettings timed out after 5 seconds; proceeding anyway")
         }
     }


### PR DESCRIPTION
This PR replaces path monitor with key value observer (KVO) for `NEPacketTunnelProvider.defaultPath` which is by far seems to be less noisy and reports changes as primary interface is fully changed skipping intermediate steps where interfaces shuffle. 

For example connecting to Wi-Fi produces one KVO notification as opposed to a couple of them when using `NWPathMonitor`. `defaultPath` also reports the _real_ status of primary interface connectivity, so no need to do any heuristics (one interface available or many, how many are physical etc..). 

Note that `NWPath.isEqual(to: NWPath)` almost always returns `false`. I feel like the only time it returns `true` is when you give it exact same instance of `NWPath`. So that should work fine with LTE when roaming around.

We need to thoroughly test it though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/6)
<!-- Reviewable:end -->
