### PR TITLE
Update manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,7 @@ let package = Package(
     name: "WireGuardKit",
     platforms: [
         .macOS(.v12),
-        .iOS(.v15)
+        .iOS(.v13)
     ],
     products: [
         .library(name: "WireGuardKit", targets: ["WireGuardKit"]),

--- a/Sources/WireGuardKitGo/Makefile
+++ b/Sources/WireGuardKitGo/Makefile
@@ -21,6 +21,11 @@ GOARCH_x86_64 := amd64
 GOOS_macosx := darwin
 GOOS_iphoneos := ios
 
+UNAME := $(shell uname -m)
+ifeq ($(UNAME), $(GOARCH_arm64))
+	GOOS_iphonesimulator := ios
+endif
+
 build: $(DESTDIR)/libwg-go.a
 version-header: $(DESTDIR)/wireguard-go-version.h
 


### PR DESCRIPTION
- Bump version of manifest to 5.5
- Lower iOS version to 13
- Cherry pick m1 support from `563ea23e44667bd8328de154b248b766cafe7d6d`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/7)
<!-- Reviewable:end -->
