### PR TITLE
Make WireGuardKitTypes a dynamic library IOS-191

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,13 +11,13 @@ let package = Package(
     ],
     products: [
         .library(name: "WireGuardKit", targets: ["WireGuardKit"]),
-        .library(name: "WireGuardKitTypes", targets: ["WireGuardKitTypes"])
+        .library(name: "WireGuardKitTypes", type: .dynamic, targets: ["WireGuardKitTypes"])
     ],
     dependencies: [],
     targets: [
         .target(
             name: "WireGuardKit",
-            dependencies: ["WireGuardKitC", "WireGuardKitGo", "WireGuardKitTypes"]
+            dependencies: ["WireGuardKitGo", "WireGuardKitTypes"]
         ),
         .target(
             name: "WireGuardKitTypes",

--- a/WireGuard.xcodeproj/project.pbxproj
+++ b/WireGuard.xcodeproj/project.pbxproj
@@ -491,7 +491,8 @@
 				5807481527DB7DC00020ECBF /* PrivateKey.swift */,
 				5807481227DB7DC00020ECBF /* TunnelConfiguration.swift */,
 			);
-			path = WireGuardKitTypes;
+			name = WireGuardKitTypes;
+			path = Sources/WireGuardKitTypes;
 			sourceTree = "<group>";
 		};
 		585B10452577E293004F691E /* WireGuardKit */ = {


### PR DESCRIPTION
This PR makes WireGuardKitTypes a dynamic framework so we could link against them from `MullvadTypes`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/8)
<!-- Reviewable:end -->
