### PR TITLE
Include default IPv4 and IPv6 routes when configuring network settings

### DIFF
--- a/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
+++ b/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
@@ -149,6 +149,12 @@ class PacketTunnelSettingsGenerator {
         var ipv4IncludedRoutes = [NEIPv4Route]()
         var ipv6IncludedRoutes = [NEIPv6Route]()
 
+        let defaultIPv4Route = NEIPv4Route.default()
+        ipv4IncludedRoutes.append(defaultIPv4Route)
+
+        let defaultIPv6Route = NEIPv6Route.default()
+        ipv6IncludedRoutes.append(defaultIPv6Route)
+
         for addressRange in tunnelConfiguration.interface.addresses {
             if addressRange.address is IPv4Address {
                 let route = NEIPv4Route(destinationAddress: "\(addressRange.maskedAddress())", subnetMask: "\(addressRange.subnetMask())")


### PR DESCRIPTION
This PR adds the default IPv4 and IPv6 routes when generating network settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/9)
<!-- Reviewable:end -->
