### PR TITLE
Fix IOS-758 by reinstating minimum offset for buffers

### DIFF
--- a/Sources/WireGuardKitGo/router.go
+++ b/Sources/WireGuardKitGo/router.go
@@ -14,8 +14,10 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 )
 
-// The standard packet offset, which WireGuardGo expects
-const defaultOffset = 16
+// The standard packet offset, which WireGuardGo's real tunnel device expects to be at least 4
+// when reading.
+// See: https://github.com/WireGuard/wireguard-go/blob/12269c2761734b15625017d8565745096325392f/tun/tun_darwin.go#L228
+const defaultOffset = 4
 
 // how many buffers we should preallocate.
 // Currently, WireGuardGo sends buffers one at a time, so this is 1, though the API says that


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/13)
<!-- Reviewable:end -->
