### PR TITLE
Use the mullvad fork of wireguard-go

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Sources/WireGuardKitGo/wireguard-go"]
+	path = Sources/WireGuardKitGo/wireguard-go
+	url = https://github.com/mullvad/wireguard-go

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
                 "Makefile"
             ],
             publicHeadersPath: ".",
-            linkerSettings: [.linkedLibrary("wg-go")]
+            linkerSettings: [.linkedLibrary("wg-go"), .linkedLibrary("maybenot")]
         )
     ]
 )

--- a/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
+++ b/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
@@ -145,10 +145,12 @@ struct DeviceConfiguration {
 class PacketTunnelSettingsGenerator {
     let exit: DeviceConfiguration
     let entry: DeviceConfiguration?
+    let daita: DaitaConfiguration?
 
-    init(exit: DeviceConfiguration, entry: DeviceConfiguration? = nil) {
+    init(exit: DeviceConfiguration, entry: DeviceConfiguration? = nil, daita: DaitaConfiguration? = nil) {
         self.exit = exit
         self.entry = entry
+        self.daita = daita
     }
 
     func entryUapiConfiguration() -> (String, [EndpointResolutionResult?])? {
@@ -200,11 +202,11 @@ class PacketTunnelSettingsGenerator {
     func generateNetworkSettings() -> NEPacketTunnelNetworkSettings {
         exit.generateNetworkSettings()
     }
-    
+
     func endpointUapiConfiguration() -> (String, [EndpointResolutionResult?]) {
         exit.endpointUapiConfiguration()
     }
-    
+
     func entryEndpointUapiConfiguration() -> (String, [EndpointResolutionResult?])? {
         entry?.endpointUapiConfiguration()
     }
@@ -217,3 +219,4 @@ class PacketTunnelSettingsGenerator {
             }
     }
 }
+

--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -25,7 +25,7 @@ public enum WireGuardAdapterError: Error {
 
     /// Failure to start WireGuard backend.
     case startWireGuardBackend(Int32)
-    
+
     /// Config has no private IPs.
     case noInterfaceIp
 }
@@ -187,7 +187,7 @@ public class WireGuardAdapter {
         }
     }
     
-    public func startMultihop(exitConfiguration: TunnelConfiguration, entryConfiguration: TunnelConfiguration?, completionHandler: @escaping (WireGuardAdapterError?) -> Void) {
+    public func startMultihop(exitConfiguration: TunnelConfiguration, entryConfiguration: TunnelConfiguration?, daita: DaitaConfiguration? = nil, completionHandler: @escaping (WireGuardAdapterError?) -> Void) {
         workQueue.async {
             guard case .stopped = self.state else {
                 completionHandler(.invalidState)
@@ -204,7 +204,7 @@ public class WireGuardAdapter {
             self.addDefaultPathObserver()
 
             do {
-                let settingsGenerator = try self.makeSettingsGenerator(with: exitConfiguration, entryConfiguration: entryConfiguration)
+                let settingsGenerator = try self.makeSettingsGenerator(with: exitConfiguration, entryConfiguration: entryConfiguration, daita: daita)
                 try self.setNetworkSettings(settingsGenerator.generateNetworkSettings())
 
                 let (exitWgConfig, resolutionResults) = settingsGenerator.uapiConfiguration()
@@ -212,7 +212,7 @@ public class WireGuardAdapter {
                 self.logEndpointResolutionResults(resolutionResults)
 
                 self.state = .started(
-                    try self.startWireGuardBackend(exitWgConfig: exitWgConfig, privateAddress: privateAddress, entryWgConfig: entryWgConfig, mtu: 1280),
+                    try self.startWireGuardBackend(exitWgConfig: exitWgConfig, privateAddress: privateAddress, entryWgConfig: entryWgConfig, mtu: 1280, daita: daita),
                     settingsGenerator
                 )
 
@@ -231,7 +231,7 @@ public class WireGuardAdapter {
     /// - Parameters:
     ///   - tunnelConfiguration: tunnel configuration.
     ///   - completionHandler: completion handler.
-    public func start(tunnelConfiguration: TunnelConfiguration, completionHandler: @escaping (WireGuardAdapterError?) -> Void) {
+    public func start(tunnelConfiguration: TunnelConfiguration, daita: DaitaConfiguration? = nil, completionHandler: @escaping (WireGuardAdapterError?) -> Void) {
         startMultihop(exitConfiguration: tunnelConfiguration, entryConfiguration: nil, completionHandler: completionHandler)
     }
 
@@ -425,17 +425,17 @@ public class WireGuardAdapter {
     /// - Parameter wgConfig: WireGuard configuration
     /// - Throws: an error of type `WireGuardAdapterError`
     /// - Returns: tunnel handle
-    private func startWireGuardBackend(exitWgConfig: String, privateAddress: IPAddress, entryWgConfig: String? = nil, mtu: UInt16 = 1280) throws -> Int32 {
+    private func startWireGuardBackend(exitWgConfig: String, privateAddress: IPAddress, entryWgConfig: String? = nil, mtu: UInt16 = 1280, daita: DaitaConfiguration?) throws -> Int32 {
         guard let tunnelFileDescriptor = self.tunnelFileDescriptor else {
             throw WireGuardAdapterError.cannotLocateTunnelFileDescriptor
         }
 
         let privateAddr = "\(privateAddress)"
-
+        
         let handle = if let entryWgConfig {
-            wgTurnOnMultihop(exitWgConfig, entryWgConfig, privateAddr, tunnelFileDescriptor)
+            wgTurnOnMultihop(exitWgConfig, entryWgConfig, privateAddr, tunnelFileDescriptor, daita?.machines ?? nil, daita?.maxEvents ?? 0, daita?.maxActions ?? 0)
         } else {
-            wgTurnOn(exitWgConfig, tunnelFileDescriptor)
+            wgTurnOn(exitWgConfig, tunnelFileDescriptor, daita?.machines ?? nil, daita?.maxEvents ?? 0, daita?.maxActions ?? 0)
         }
         if handle < 0 {
             throw WireGuardAdapterError.startWireGuardBackend(handle)
@@ -451,7 +451,7 @@ public class WireGuardAdapter {
     /// - Parameter entryConfiguration: an optional instance of type `TunnelConfiguration` for the entry WireGuard device
     /// - Throws: an error of type `WireGuardAdapterError`.
     /// - Returns: an instance of type `PacketTunnelSettingsGenerator`.
-    private func makeSettingsGenerator(with exitConfiguration: TunnelConfiguration, entryConfiguration: TunnelConfiguration? = nil) throws -> PacketTunnelSettingsGenerator {
+    private func makeSettingsGenerator(with exitConfiguration: TunnelConfiguration, entryConfiguration: TunnelConfiguration? = nil, daita: DaitaConfiguration? = nil) throws -> PacketTunnelSettingsGenerator {
         let resolvedExitEndpoints = try self.resolvePeers(for: exitConfiguration)
         
         var entry: DeviceConfiguration? = nil
@@ -557,7 +557,7 @@ public class WireGuardAdapter {
                 self.logEndpointResolutionResults(resolutionResults)
 
                 self.state = .started(
-                    try self.startWireGuardBackend(exitWgConfig: exitWgConfig, privateAddress: privateAddress),
+                    try self.startWireGuardBackend(exitWgConfig: exitWgConfig, privateAddress: privateAddress, daita: settingsGenerator.daita),
                     settingsGenerator
                 )
             } catch {

--- a/Sources/WireGuardKitGo/Makefile
+++ b/Sources/WireGuardKitGo/Makefile
@@ -9,6 +9,8 @@ SDKROOT ?= $(shell xcrun --sdk $(PLATFORM_NAME) --show-sdk-path)
 CONFIGURATION_BUILD_DIR ?= $(CURDIR)/out
 CONFIGURATION_TEMP_DIR ?= $(CURDIR)/.tmp
 
+BUILT_PRODUCTS_DIR ?= $(CURDIR)
+
 export PATH := $(PATH):/usr/local/bin:/opt/homebrew/bin
 export CC ?= clang
 LIPO ?= lipo
@@ -23,6 +25,7 @@ GOOS_iphoneos := ios
 RUST_TARGET_iphoneos := "ios"
 RUST_TARGET_ipados := "ios"
 RUST_TARGET_iphonesimulator := "ios-sim"
+RUST_TARGET_macosx := "darwin"
 RUST_arm64 := aarch64
 RUST_x86_64 := x86_64
 
@@ -51,12 +54,12 @@ $(BUILDDIR)/libwg-go-$(1).a: export GOOS := $(GOOS_$(PLATFORM_NAME))
 $(BUILDDIR)/libwg-go-$(1).a: export GOARCH := $(GOARCH_$(1))
 $(BUILDDIR)/libwg-go-$(1).a: $(GOROOT)/.prepared go.mod
 	git submodule update --init --recursive
-	 CARGO_TARGET_DIR=$(BUILDDIR)/target \
-			  DESTINATION=$(BUILT_PRODUCTS_DIR) \
-			  PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:" \
-			  CARGO=$(HOME)/.cargo/bin/cargo \
-			  TARGET=$(RUST_$(1))-apple-$(RUST_TARGET_$(PLATFORM_NAME)) \
-			  make -C wireguard-go/maybenot/crates/maybenot-ffi
+	CARGO_TARGET_DIR=$(BUILDDIR)/target \
+			DESTINATION=$(BUILT_PRODUCTS_DIR) \
+			PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:" \
+			CARGO=$(HOME)/.cargo/bin/cargo \
+			TARGET=$(RUST_$(1))-apple-$(RUST_TARGET_$(PLATFORM_NAME)) \
+			make -C wireguard-go/maybenot/crates/maybenot-ffi
 	go build --tags daita -ldflags=-w -trimpath -ldflags=L=$(BUILDDIR)/ -v -o "$(BUILDDIR)/libwg-go-$(1).a" -buildmode c-archive
 	rm -f "$(BUILDDIR)/libwg-go-$(1).h"
 endef
@@ -71,7 +74,14 @@ $(DESTDIR)/libwg-go.a: $(foreach ARCH,$(ARCHS),$(BUILDDIR)/libwg-go-$(ARCH).a)
 
 clean:
 	rm -rf "$(BUILDDIR)" "$(DESTDIR)/libwg-go.a" "$(DESTDIR)/wireguard-go-version.h"
+	rm -f libmaybenot.a
+	rm -rf $(CONFIGURATION_BUILD_DIR)
+	make -C wireguard-go clean
+
+test: build
+	make -C wireguard-go daita
+	go test -tags daita ./... -count=1
 
 install: build
 
-.PHONY: clean build version-header install
+.PHONY: clean build version-header install test

--- a/Sources/WireGuardKitGo/Makefile
+++ b/Sources/WireGuardKitGo/Makefile
@@ -20,6 +20,11 @@ GOARCH_arm64 := arm64
 GOARCH_x86_64 := amd64
 GOOS_macosx := darwin
 GOOS_iphoneos := ios
+RUST_TARGET_iphoneos := "ios"
+RUST_TARGET_ipados := "ios"
+RUST_TARGET_iphonesimulator := "ios-sim"
+RUST_arm64 := aarch64
+RUST_x86_64 := x86_64
 
 UNAME := $(shell uname -m)
 ifeq ($(UNAME), $(GOARCH_arm64))
@@ -45,7 +50,14 @@ $(BUILDDIR)/libwg-go-$(1).a: export CGO_LDFLAGS := $(CFLAGS_PREFIX) $(ARCH)
 $(BUILDDIR)/libwg-go-$(1).a: export GOOS := $(GOOS_$(PLATFORM_NAME))
 $(BUILDDIR)/libwg-go-$(1).a: export GOARCH := $(GOARCH_$(1))
 $(BUILDDIR)/libwg-go-$(1).a: $(GOROOT)/.prepared go.mod
-	go build -ldflags=-w -trimpath -v -o "$(BUILDDIR)/libwg-go-$(1).a" -buildmode c-archive
+	git submodule update --init --recursive
+	 CARGO_TARGET_DIR=$(BUILDDIR)/target \
+			  DESTINATION=$(BUILT_PRODUCTS_DIR) \
+			  PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:" \
+			  CARGO=$(HOME)/.cargo/bin/cargo \
+			  TARGET=$(RUST_$(1))-apple-$(RUST_TARGET_$(PLATFORM_NAME)) \
+			  make -C wireguard-go/maybenot/crates/maybenot-ffi
+	go build --tags daita -ldflags=-w -trimpath -ldflags=L=$(BUILDDIR)/ -v -o "$(BUILDDIR)/libwg-go-$(1).a" -buildmode c-archive
 	rm -f "$(BUILDDIR)/libwg-go-$(1).h"
 endef
 $(foreach ARCH,$(ARCHS),$(eval $(call libwg-go-a,$(ARCH))))

--- a/Sources/WireGuardKitGo/go.mod
+++ b/Sources/WireGuardKitGo/go.mod
@@ -3,19 +3,21 @@ module golang.zx2c4.com/wireguard/apple
 go 1.20
 
 require (
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/crypto v0.13.0
+	golang.org/x/net v0.15.0
 	golang.org/x/sys v0.12.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
+	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
-	golang.org/x/crypto v0.13.0 // indirect
-	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 // indirect
 )
+
+replace golang.zx2c4.com/wireguard => ./wireguard-go

--- a/Sources/WireGuardKitGo/go.sum
+++ b/Sources/WireGuardKitGo/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
+github.com/mullvad/wireguard-go v0.0.0-20240722122257-74f4174d3b58 h1:Aoa/ApY3YJ9lh7h6zMjEbnmLC2IZtYy4NuysWJwf2P8=
+github.com/mullvad/wireguard-go v0.0.0-20240722122257-74f4174d3b58/go.mod h1:fPqWRU7VpVieazgD2C8+dXBq2azXX5jMTieSaJAU15Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
@@ -16,8 +18,7 @@ golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 h1:vVKdlvoWBphwdxWKrFZEuM0k
 golang.org/x/time v0.0.0-20220210224613-90d013bbcef8/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
-golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uIfPMv78iAJGcPKDeqAFnaLBropIC4=
-golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/Sources/WireGuardKitGo/multihoptun/bind.go
+++ b/Sources/WireGuardKitGo/multihoptun/bind.go
@@ -38,53 +38,39 @@ func (st *multihopBind) Open(port uint16) (fns []conn.ReceiveFunc, actualPort ui
 
 	actualPort = st.localPort
 	fns = []conn.ReceiveFunc{
-		func(packets [][]byte, sizes []int, eps []conn.Endpoint) (n int, err error) {
+		func(packet []byte) (bytesRead int, ep conn.Endpoint, err error) {
 			var batch packetBatch
 			var ok bool
 
 			select {
 			case <-st.shutdownChan:
-				return 0, net.ErrClosed
+				return 0, ep, net.ErrClosed
 			case <-st.socketShutdown:
-				return 0, net.ErrClosed
+				return 0, ep, net.ErrClosed
 			case batch, ok = <-st.writeRecv:
 				break
 			}
 			if !ok {
-				return 0, net.ErrClosed
+				return 0, ep, net.ErrClosed
 			}
 
-			packetsToProcess := len(packets)
-			if len(batch.packets) < packetsToProcess {
-				packetsToProcess = len(batch.packets)
+			ipVersion := header.IPVersion(batch.packet[batch.offset:])
+			if ipVersion == 4 {
+				v4 := header.IPv4(batch.packet[batch.offset:])
+				udp := header.UDP(v4.Payload())
+				copy(packet, udp.Payload())
+				bytesRead = len(udp.Payload())
+
+			} else if ipVersion == 6 {
+				v6 := header.IPv6(batch.packet[batch.offset:])
+				udp := header.UDP(v6.Payload())
+				copy(packet, udp.Payload())
+				bytesRead = len(udp.Payload())
 			}
+			batch.size = bytesRead
+			ep = st.endpoint
 
-			for idx := 0; idx < packetsToProcess; idx += 1 {
-				rxPacket := batch.packets[idx][batch.offset:]
-				ipVersion := header.IPVersion(rxPacket)
-				if ipVersion == 4 {
-					var v4 header.IPv4
-					var udp header.UDP
-					v4 = rxPacket
-					udp = v4.Payload()
-					copy(packets[idx], udp.Payload())
-					sizes[idx] = len(udp.Payload())
-
-				} else if ipVersion == 6 {
-					var v6 header.IPv6
-					var udp header.UDP
-					v6 = rxPacket
-					udp = v6.Payload()
-					copy(packets[idx], udp.Payload())
-					sizes[idx] = len(udp.Payload())
-				}
-
-				eps[idx] = st.endpoint
-				n += 1
-			}
-			batch.packetsCopied = n
 			batch.completion <- batch
-
 			return
 		},
 	}
@@ -98,7 +84,7 @@ func (*multihopBind) ParseEndpoint(s string) (conn.Endpoint, error) {
 }
 
 // Send implements conn.Bind.
-func (st *multihopBind) Send(bufs [][]byte, ep conn.Endpoint) error {
+func (st *multihopBind) Send(buf []byte, ep conn.Endpoint) error {
 	var packetBatch packetBatch
 	var ok bool
 
@@ -119,18 +105,10 @@ func (st *multihopBind) Send(bufs [][]byte, ep conn.Endpoint) error {
 		return net.ErrClosed
 	}
 
-	var err error
-	var size int
-	packetBatch.packetsCopied = 0
-	for idx := range bufs {
-		targetPacket := packetBatch.packets[idx][packetBatch.offset:]
-		size, err = st.writePayload(targetPacket[:], bufs[idx])
-		if err != nil {
-			continue
-		}
-		packetBatch.sizes[idx] = size
-		packetBatch.packetsCopied += 1
-	}
+	targetPacket := packetBatch.packet[packetBatch.offset:]
+	size, err := st.writePayload(targetPacket, buf)
+
+	packetBatch.size = size
 
 	packetBatch.completion <- packetBatch
 

--- a/Sources/WireGuardKitGo/multihoptun/tun.go
+++ b/Sources/WireGuardKitGo/multihoptun/tun.go
@@ -50,13 +50,15 @@ type MultihopTun struct {
 }
 
 type packetBatch struct {
-	packets [][]byte
-	sizes   []int
-	offset  int
-	// indicates how many packets are copied into `packets`, since offsets can be used.
-	packetsCopied int
+	packet []byte
+	size   int
+	offset int
 	// to be used to return the packet batch back to tun.Read and tun.Write
 	completion chan packetBatch
+}
+
+func (pb *packetBatch) Size() int {
+	return len(pb.packet)
 }
 
 func NewMultihopTun(local, remote netip.Addr, remotePort uint16, mtu int) MultihopTun {
@@ -117,12 +119,12 @@ func (*MultihopTun) Name() (string, error) {
 }
 
 // Write implements tun.Device.
-func (st *MultihopTun) Write(bufs [][]byte, offset int) (int, error) {
-
+func (st *MultihopTun) Write(packet []byte, offset int) (int, error) {
 	completion := make(chan packetBatch)
 	packetBatch := packetBatch{
-		packets:    bufs,
+		packet:     packet,
 		offset:     offset,
+		size:       len(packet),
 		completion: completion,
 	}
 
@@ -139,15 +141,15 @@ func (st *MultihopTun) Write(bufs [][]byte, offset int) (int, error) {
 		return 0, io.EOF
 	}
 
-	return packetBatch.packetsCopied, nil
+	return packetBatch.size, nil
 }
 
 // Read implements tun.Device.
-func (st *MultihopTun) Read(bufs [][]byte, sizes []int, offset int) (n int, err error) {
+func (st *MultihopTun) Read(packet []byte, offset int) (n int, err error) {
 	completion := make(chan packetBatch)
 	packetBatch := packetBatch{
-		packets:    bufs,
-		sizes:      sizes,
+		packet:     packet,
+		size:       0,
 		offset:     offset,
 		completion: completion,
 	}
@@ -166,7 +168,7 @@ func (st *MultihopTun) Read(bufs [][]byte, sizes []int, offset int) (n int, err 
 		return 0, io.EOF
 	}
 
-	return packetBatch.packetsCopied, nil
+	return packetBatch.size, nil
 }
 
 func (st *MultihopTun) writePayload(target, payload []byte) (size int, err error) {
@@ -284,7 +286,12 @@ func (st *MultihopTun) headerSize() int {
 
 // BatchSize implements conn.Bind.
 func (*MultihopTun) BatchSize() int {
-	return conn.IdealBatchSize
+	return 128
+}
+
+// BatchSize implements conn.Bind.
+func (*MultihopTun) Flush() error {
+	return nil
 }
 
 // Close implements tun.Device

--- a/Sources/WireGuardKitGo/router.go
+++ b/Sources/WireGuardKitGo/router.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sync"
 
-	"golang.zx2c4.com/wireguard/conn"
 	"golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/tun"
 	"gvisor.dev/gvisor/pkg/tcpip"
@@ -23,30 +22,26 @@ const defaultOffset = 4
 // how many buffers we should preallocate.
 // Currently, WireGuardGo sends buffers one at a time, so this is 1, though the API says that
 // this is not set in stone.
-const expectedBufferCount = conn.IdealBatchSize
+const expectedBufferCount = 128
 
+// A packet batch contains within itself a buffer used to store packet data and
+// whether it is a virtual packet or not. This allows an individual reader
+// goroutine to send a read packet to whatever `Router.Read` where its contents
+// will be copied over. This is essential for multiplexing between different
+// devices.
 type PacketBatch struct {
-	packets   [][]byte
-	sizes     []int
-	isVirtual bool
+	packet     []byte
+	isVirtual  bool
+	completion chan *PacketBatch
 }
 
-// truncate a PacketBatch to a maximum size, allocating and returning a new PacketBatch to
-// hold the overflow if needed.  The function for allocating the batch is injected, to decouple
-// this from specific memory management methods (such as the use of a Pool, as in practice, or
-// simple allocation, as in tests)
-func (pb *PacketBatch) truncate(limit int, makeBatch func() *PacketBatch) *PacketBatch {
-	excess := len(pb.packets) - limit
-	if excess <= 0 {
-		return nil
-	}
-	overflow := makeBatch()
-	overflow.packets = pb.packets[limit:]
-	overflow.sizes = pb.sizes[limit:]
-	overflow.isVirtual = pb.isVirtual
-	pb.packets = pb.packets[:limit]
-	pb.sizes = pb.sizes[:limit]
-	return overflow
+// A router routes traffic between two different tunnel devices. This allows us
+// to multiplex between real, user traffic and our own virtual networking stack
+// to work around iOS limitations.
+type Router struct {
+	real, virtual tun.Device
+	read          routerRead
+	write         routerWrite
 }
 
 type routerRead struct {
@@ -55,8 +50,6 @@ type routerRead struct {
 	rxChannel        chan *PacketBatch
 	rxShutdown       chan struct{}
 	waitGroup        *sync.WaitGroup
-	overflow         *PacketBatch
-	batchPool        *sync.Pool
 	errorChannel     chan error
 	error            error
 }
@@ -64,19 +57,6 @@ type routerRead struct {
 type routerWrite struct {
 	virtualRoutes    map[PacketIdentifier]bool
 	virtualRouteChan chan PacketIdentifier
-	realPackets      [][]byte
-	virtualPackets   [][]byte
-}
-
-type Router struct {
-	real, virtual tun.Device
-	read          routerRead
-	write         routerWrite
-}
-
-// BatchSize implements tun.Device.
-func (r *Router) BatchSize() int {
-	return r.real.BatchSize()
 }
 
 // Close implements tun.Device.
@@ -84,7 +64,6 @@ func (r *Router) Close() error {
 	close(r.read.rxShutdown)
 	err1 := r.real.Close()
 	err2 := r.virtual.Close()
-	r.read.waitGroup.Wait()
 	if err1 != nil {
 		return err1
 	}
@@ -109,6 +88,12 @@ func (r *Router) MTU() (int, error) {
 // Name implements tun.Device.
 func (r *Router) Name() (string, error) {
 	return r.real.Name()
+}
+
+// Name implements tun.Device.
+func (r *Router) Flush() error {
+	r.virtual.Flush()
+	return r.real.Flush()
 }
 
 type PacketHeaderData struct {
@@ -199,47 +184,40 @@ func (r *routerRead) setVirtualRoute(header PacketHeaderData) {
 }
 
 // Read implements tun.Device.
-func (r *Router) Read(bufs [][]byte, sizes []int, offset int) (n int, err error) {
+func (r *Router) Read(bufs []byte, offset int) (n int, err error) {
 	// this could theoretically be executed in parallel, but we don't currently do that.
 	// this code is in itself not parallel-safe, so add locking or similar if this changes
-	var packetBatch *PacketBatch
+	var batch *PacketBatch
 	if r.read.error != nil {
 		return 0, r.read.error
 	}
-	if r.read.overflow != nil {
-		packetBatch = r.read.overflow
-		r.read.overflow = nil
-	} else {
-		var ok bool
-		select {
-		case <-r.read.rxShutdown:
-			return 0, io.EOF
-		case err = <-r.read.errorChannel:
-			r.read.error = err
-			return 0, err
-		case packetBatch, ok = <-r.read.rxChannel:
-			if !ok {
-				return 0, errors.New("reader shut down")
-			}
+
+	var ok bool
+	select {
+	case err = <-r.read.errorChannel:
+		r.read.error = err
+		return 0, err
+	case _, _ = <-r.read.rxShutdown:
+		return 0, io.EOF
+	case batch, ok = <-r.read.rxChannel:
+		defer func() {
+			batch.completion <- batch
+		}()
+		if !ok {
+			return 0, errors.New("reader shut down")
 		}
 	}
-	defer func() {
-		r.read.batchPool.Put(packetBatch)
-	}()
 
-	r.read.overflow = packetBatch.truncate(len(bufs), func() *PacketBatch { return r.read.batchPool.Get().(*PacketBatch) })
 	headerData := PacketHeaderData{}
-	for packetIndex := range packetBatch.packets {
+	packet := batch.packet
 
-		copy(bufs[packetIndex][offset:], packetBatch.packets[packetIndex][defaultOffset:])
-		sizes[packetIndex] = packetBatch.sizes[packetIndex]
+	copy(bufs[offset:], packet)
 
-		if packetBatch.isVirtual && fillPacketHeaderData(bufs[packetIndex][offset:], &headerData, false) {
-			r.read.setVirtualRoute(headerData)
-		}
+	if batch.isVirtual && fillPacketHeaderData(bufs[offset:], &headerData, false) {
+		r.read.setVirtualRoute(headerData)
 	}
 
-	return len(packetBatch.packets), nil
+	return len(packet), nil
 }
 
 func (r *routerWrite) updateVirtualRoutes() {
@@ -254,43 +232,22 @@ func (r *routerWrite) updateVirtualRoutes() {
 }
 
 // Write implements tun.Device.
-func (r *Router) Write(bufs [][]byte, offset int) (int, error) {
+func (r *Router) Write(packet []byte, offset int) (int, error) {
 	r.write.updateVirtualRoutes()
 
 	headerData := PacketHeaderData{}
-	r.write.realPackets = r.write.realPackets[:0]
-	r.write.virtualPackets = r.write.virtualPackets[:0]
 
-	for packetIdx, packetRef := range bufs {
-		isVirtual := false
-		if fillPacketHeaderData(packetRef[offset:], &headerData, true) {
-			identifier := headerData.asPacketIdentifier()
-			_, isVirtual = r.write.virtualRoutes[identifier]
-		}
-
-		if !isVirtual {
-			r.write.realPackets = append(r.write.realPackets, bufs[packetIdx])
-		} else {
-			r.write.virtualPackets = append(r.write.virtualPackets, bufs[packetIdx])
-		}
+	isVirtual := false
+	if fillPacketHeaderData(packet[offset:], &headerData, true) {
+		identifier := headerData.asPacketIdentifier()
+		_, isVirtual = r.write.virtualRoutes[identifier]
 	}
 
-	realWritten := 0
-	virtualWritten := 0
-	var err error
-	if len(r.write.realPackets) > 0 {
-		realWritten, err = r.real.Write(r.write.realPackets, offset)
+	if !isVirtual {
+		return r.real.Write(packet, offset)
+	} else {
+		return r.virtual.Write(packet, offset)
 	}
-	if realWritten < len(r.write.realPackets) || err != nil {
-		return realWritten, err
-	}
-	if len(r.write.virtualPackets) > 0 {
-		virtualWritten, err = r.virtual.Write(r.write.virtualPackets, offset)
-	}
-	if err != nil {
-		virtualWritten = 0
-	}
-	return realWritten + virtualWritten, err
 }
 
 func initializeReadPacketBuffer(size int) [][]byte {
@@ -304,27 +261,41 @@ func initializeReadPacketBuffer(size int) [][]byte {
 
 func (r *routerRead) readWorker(device tun.Device, isVirtual bool) {
 	defer r.waitGroup.Done()
+	completion := make(chan *PacketBatch)
+	buffer := make([]byte, 1700)
+	batch := &PacketBatch{
+		packet:     buffer,
+		isVirtual:  isVirtual,
+		completion: completion,
+	}
 	for r.error == nil {
 		select {
 		case <-r.rxShutdown:
 			return
 		default:
 		}
-		batch := r.batchPool.Get().(*PacketBatch)
-		_, err := device.Read(batch.packets, batch.sizes, defaultOffset)
+		n, err := device.Read(batch.packet, defaultOffset)
 		if err != nil {
-			r.batchPool.Put(batch)
 			select {
 			case r.errorChannel <- err:
-			case <- r.rxShutdown:
+			case <-r.rxShutdown:
 			}
 			return
 		}
+		batch.packet = batch.packet[defaultOffset : n+defaultOffset]
 		batch.isVirtual = isVirtual
 		select {
-		case <- r.rxShutdown:
+		case _, _ = <-r.rxShutdown:
 			return
-		case 	r.rxChannel <- batch:
+		case r.rxChannel <- batch:
+			break
+		}
+		select {
+		case _, _ = <-r.rxShutdown:
+			return
+		case batch = <-completion:
+			batch.packet = buffer
+			break
 		}
 	}
 }
@@ -339,25 +310,12 @@ func newRouterRead(real, virtual tun.Device, virtualRouteChan chan PacketIdentif
 		rxChannel,
 		rxShutdown,
 		&sync.WaitGroup{},
-		nil,
-		&sync.Pool{
-			New: func() any {
-				batch := new(PacketBatch)
-				batch.packets = initializeReadPacketBuffer(conn.IdealBatchSize)
-				batch.sizes = make([]int, conn.IdealBatchSize)
-				return batch
-			},
-		},
 		errorChannel,
 		nil,
 	}
 	go result.readWorker(real, false)
 	go result.readWorker(virtual, true)
 	result.waitGroup.Add(2)
-	go func() {
-		result.waitGroup.Wait()
-		close(result.rxChannel)
-	}()
 	return result
 }
 
@@ -365,8 +323,6 @@ func newRouterWrite(virtualRouteChan chan PacketIdentifier) routerWrite {
 	return routerWrite{
 		map[PacketIdentifier]bool{},
 		virtualRouteChan,
-		make([][]byte, 0, expectedBufferCount),
-		make([][]byte, 0, expectedBufferCount),
 	}
 }
 

--- a/Sources/WireGuardKitGo/wireguard.h
+++ b/Sources/WireGuardKitGo/wireguard.h
@@ -13,8 +13,8 @@
 typedef void(*logger_fn_t)(void *context, int level, const char *msg);
 extern void wgSetLogger(void *context, logger_fn_t logger_fn);
 extern int wgTurnOnIAN(const char *settings, int32_t tun_fd, const char *private_ip);
-extern int wgTurnOn(const char *settings, int32_t tun_fd);
-extern int wgTurnOnMultihop(const char *exitSettings, const char *entrySettings, const char *privateIp, int32_t tun_fd);
+extern int wgTurnOn(const char *settings, int32_t tun_fd, const char *maybeNotMachines, uint32_t maybeNotMaxEvents, uint32_t maybeNotMaxActions);
+extern int wgTurnOnMultihop(const char *exitSettings, const char *entrySettings, const char *privateIp, int32_t tun_fd, const char *maybenotMachines, uint32_t maybeNotMaxEvents, uint32_t maybeNotMaxActons);
 extern void wgTurnOff(int handle);
 extern int64_t wgSetConfig(int handle, const char *exitSettings, const char *entrySettings);
 extern char *wgGetConfig(int handle);

--- a/Sources/WireGuardKitTypes/TunnelConfiguration.swift
+++ b/Sources/WireGuardKitTypes/TunnelConfiguration.swift
@@ -39,3 +39,20 @@ extension TunnelConfiguration: Equatable {
             Set(lhs.peers) == Set(rhs.peers)
     }
 }
+
+
+/// Contains arguments needed to initialize DAITA for a WireGuard device.
+public struct DaitaConfiguration {
+    /// Contains a string describing a set of DAITA machines.
+    public let machines: String
+    /// Maximum amount of DAITA events to enqueue at any given time.
+    public let maxEvents: UInt32
+    /// Maximum amount of DAITA actions to enqueue at any given time.
+    public let maxActions: UInt32
+
+    public init(machines: String, maxEvents: UInt32, maxActions: UInt32) {
+        self.machines = machines
+        self.maxEvents = maxEvents
+        self.maxActions = maxActions
+    }
+}


### PR DESCRIPTION
To be able to use DAITA on iOS, we must use our own fork of wireguard-go. Since we started our work here based on a newer version, some backporting took place. Namely, the newer interface of `Device` requires vectored reads and writes whereas the stable version does not, but this helps make the code here somewhat simpler.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/15)
<!-- Reviewable:end -->
