### PR TITLE
Fix race condition and disable IAN

### DIFF
--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -435,7 +435,7 @@ public class WireGuardAdapter {
         let handle = if let entryWgConfig {
             wgTurnOnMultihop(exitWgConfig, entryWgConfig, privateAddr, tunnelFileDescriptor)
         } else {
-            wgTurnOnIAN(exitWgConfig, tunnelFileDescriptor, privateAddr)
+            wgTurnOn(exitWgConfig, tunnelFileDescriptor)
         }
         if handle < 0 {
             throw WireGuardAdapterError.startWireGuardBackend(handle)


### PR DESCRIPTION
In this PR, I'm fixing a deadlock in `Router.Close()`. Previously, the `readWorkers` would not reliably shut down. 

And, I'm also stopping the use if `wgTurnOnIAN` - mostly because as of now, the performance of it is not good enough. But in the coming `use-the-mole-fork` branch where we will be using our wireguard-go fork, it is fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/16)
<!-- Reviewable:end -->
