### PR TITLE
Wait groups bad

### DIFF
--- a/Sources/WireGuardKitGo/multihoptun/bind.go
+++ b/Sources/WireGuardKitGo/multihoptun/bind.go
@@ -41,8 +41,8 @@ func (st *multihopBind) Open(port uint16) (fns []conn.ReceiveFunc, actualPort ui
 			var ok bool
 
 			select {
-			case _, _ = <-st.shutdownChan:
-			case _, _ = <-st.socketShutdown:
+			case <-st.shutdownChan:
+			case <-st.socketShutdown:
 				return 0, net.ErrClosed
 			case batch, ok = <-st.writeRecv:
 				break
@@ -103,8 +103,8 @@ func (st *multihopBind) Send(bufs [][]byte, ep conn.Endpoint) error {
 	var ok bool
 
 	select {
-	case _, _ = <-st.shutdownChan:
-	case _, _ = <-st.socketShutdown:
+	case <-st.shutdownChan:
+	case <-st.socketShutdown:
 		// it is important to return a net.ErrClosed, since it implements the
 		// net.Error interface and indicates that it is not a recoverable error.
 		// wg-go uses the net.Error interface to deduce if it should try to send

--- a/Sources/WireGuardKitGo/multihoptun/bind.go
+++ b/Sources/WireGuardKitGo/multihoptun/bind.go
@@ -44,6 +44,7 @@ func (st *multihopBind) Open(port uint16) (fns []conn.ReceiveFunc, actualPort ui
 
 			select {
 			case <-st.shutdownChan:
+				return 0, net.ErrClosed
 			case <-st.socketShutdown:
 				return 0, net.ErrClosed
 			case batch, ok = <-st.writeRecv:
@@ -85,6 +86,7 @@ func (st *multihopBind) Open(port uint16) (fns []conn.ReceiveFunc, actualPort ui
 			select {
 			case batch.completion <- batch:
 			case <-st.shutdownChan:
+				return 0, net.ErrClosed
 			}
 
 			return
@@ -106,6 +108,7 @@ func (st *multihopBind) Send(bufs [][]byte, ep conn.Endpoint) error {
 
 	select {
 	case <-st.shutdownChan:
+		return net.ErrClosed
 	case <-st.socketShutdown:
 		// it is important to return a net.ErrClosed, since it implements the
 		// net.Error interface and indicates that it is not a recoverable error.

--- a/Sources/WireGuardKitGo/multihoptun/bind.go
+++ b/Sources/WireGuardKitGo/multihoptun/bind.go
@@ -83,11 +83,7 @@ func (st *multihopBind) Open(port uint16) (fns []conn.ReceiveFunc, actualPort ui
 				n += 1
 			}
 			batch.packetsCopied = n
-			select {
-			case batch.completion <- batch:
-			case <-st.shutdownChan:
-				return 0, net.ErrClosed
-			}
+			batch.completion <- batch
 
 			return
 		},
@@ -136,11 +132,7 @@ func (st *multihopBind) Send(bufs [][]byte, ep conn.Endpoint) error {
 		packetBatch.packetsCopied += 1
 	}
 
-	select {
-	case packetBatch.completion <- packetBatch:
-	case <-st.shutdownChan:
-		break
-	}
+	packetBatch.completion <- packetBatch
 
 	return err
 }

--- a/Sources/WireGuardKitGo/multihoptun/bind.go
+++ b/Sources/WireGuardKitGo/multihoptun/bind.go
@@ -32,6 +32,8 @@ func (st *multihopBind) Open(port uint16) (fns []conn.ReceiveFunc, actualPort ui
 	} else {
 		st.localPort = uint16(rand.Uint32()>>16) | 1
 	}
+	// WireGuard will close existing sockets before bringing up a new device on Bind updates.
+	// This guarantees that the socket shutdown channel is always available.
 	st.socketShutdown = make(chan struct{})
 
 	actualPort = st.localPort

--- a/Sources/WireGuardKitGo/multihoptun/tun.go
+++ b/Sources/WireGuardKitGo/multihoptun/tun.go
@@ -133,13 +133,7 @@ func (st *MultihopTun) Write(bufs [][]byte, offset int) (int, error) {
 		return 0, io.EOF
 	}
 
-	var ok bool
-	select {
-	case packetBatch, ok = <-completion:
-		break
-	case <-st.shutdownChan:
-		return 0, io.EOF
-	}
+	packetBatch, ok := <-completion
 
 	if !ok {
 		return 0, io.EOF
@@ -166,12 +160,7 @@ func (st *MultihopTun) Read(bufs [][]byte, sizes []int, offset int) (n int, err 
 	}
 
 	var ok bool
-	select {
-	case packetBatch, ok = <-completion:
-		break
-	case <-st.shutdownChan:
-		return 0, io.EOF
-	}
+	packetBatch, ok = <-completion
 
 	if !ok {
 		return 0, io.EOF

--- a/Sources/WireGuardKitGo/multihoptun/tun.go
+++ b/Sources/WireGuardKitGo/multihoptun/tun.go
@@ -129,7 +129,7 @@ func (st *MultihopTun) Write(bufs [][]byte, offset int) (int, error) {
 	select {
 	case st.writeRecv <- packetBatch:
 		break
-	case _, _ = <-st.shutdownChan:
+	case <-st.shutdownChan:
 		return 0, io.EOF
 	}
 
@@ -137,7 +137,7 @@ func (st *MultihopTun) Write(bufs [][]byte, offset int) (int, error) {
 	select {
 	case packetBatch, ok = <-completion:
 		break
-	case _, _ = <-st.shutdownChan:
+	case <-st.shutdownChan:
 		return 0, io.EOF
 	}
 
@@ -161,7 +161,7 @@ func (st *MultihopTun) Read(bufs [][]byte, sizes []int, offset int) (n int, err 
 	select {
 	case st.readRecv <- packetBatch:
 		break
-	case _, _ = <-st.shutdownChan:
+	case <-st.shutdownChan:
 		return 0, io.EOF
 	}
 
@@ -169,7 +169,7 @@ func (st *MultihopTun) Read(bufs [][]byte, sizes []int, offset int) (n int, err 
 	select {
 	case packetBatch, ok = <-completion:
 		break
-	case _, _ = <-st.shutdownChan:
+	case <-st.shutdownChan:
 		return 0, io.EOF
 	}
 

--- a/Sources/WireGuardKitGo/multihoptun/tun.go
+++ b/Sources/WireGuardKitGo/multihoptun/tun.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"net/netip"
 	"os"
-	"sync"
 	"sync/atomic"
 
 	"golang.zx2c4.com/wireguard/conn"
@@ -89,12 +88,9 @@ func NewMultihopTun(local, remote netip.Addr, remotePort uint16, mtu int) Multih
 }
 
 func (st *MultihopTun) Binder() conn.Bind {
-	waitGroup := &sync.WaitGroup{}
 	socketShutdown := make(chan struct{})
 	return &multihopBind{
 		st,
-		waitGroup,
-		atomic.Bool{},
 		socketShutdown,
 	}
 


### PR DESCRIPTION
Turns out [`WaitGroup`](https://pkg.go.dev/sync#WaitGroup)s do not support calling multiple `Done` multiple times without `Add` being called subsequently. I posit that this causes many a crash in in our TestFlight, see the thread in `#app-ios` on Thursday. Similarly, the atomic boolean is proving to be equally useless. 

I don't believe we actually need to wait for any of the `Send` or `recvFunc` calls to finish before `Close()` returns. 

Do try this out in real builds of the iOS app and run 
```
go test -race -timeout=60000s ./...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/18)
<!-- Reviewable:end -->
