### PR TITLE
Pass the DaitaConfiguration when generating packet tunnel settings

### DIFF
--- a/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
+++ b/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
@@ -219,4 +219,3 @@ class PacketTunnelSettingsGenerator {
             }
     }
 }
-

--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -431,7 +431,7 @@ public class WireGuardAdapter {
         }
 
         let privateAddr = "\(privateAddress)"
-        
+
         let handle = if let entryWgConfig {
             wgTurnOnMultihop(exitWgConfig, entryWgConfig, privateAddr, tunnelFileDescriptor, daita?.machines ?? nil, daita?.maxEvents ?? 0, daita?.maxActions ?? 0)
         } else {
@@ -449,6 +449,7 @@ public class WireGuardAdapter {
     /// Resolves the hostnames in the given tunnel configuration and return settings generator.
     /// - Parameter exitConfiguration: an instance of type `TunnelConfiguration`.
     /// - Parameter entryConfiguration: an optional instance of type `TunnelConfiguration` for the entry WireGuard device
+    /// - Parameter daita: an optional instance of type `DaitaConfiguration` for the configuration used by the Daita feature
     /// - Throws: an error of type `WireGuardAdapterError`.
     /// - Returns: an instance of type `PacketTunnelSettingsGenerator`.
     private func makeSettingsGenerator(with exitConfiguration: TunnelConfiguration, entryConfiguration: TunnelConfiguration? = nil, daita: DaitaConfiguration? = nil) throws -> PacketTunnelSettingsGenerator {
@@ -462,7 +463,8 @@ public class WireGuardAdapter {
         
         return PacketTunnelSettingsGenerator(
             exit: DeviceConfiguration(configuration: exitConfiguration, resolvedEndpoints: resolvedExitEndpoints),
-            entry: entry
+            entry: entry,
+            daita: daita
         )
     }
 


### PR DESCRIPTION
This PR makes sure that the Daita configuration is used by the packet tunnel settings generator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/19)
<!-- Reviewable:end -->
