### PR TITLE
Add support for building with Xcode 16

### DIFF
--- a/Sources/WireGuardKitC/WireGuardKitC.h
+++ b/Sources/WireGuardKitC/WireGuardKitC.h
@@ -3,6 +3,7 @@
 
 #include "key.h"
 #include "x25519.h"
+#include <sys/types.h>
 
 /* From <sys/kern_control.h> */
 #define CTLIOCGINFO 0xc0644e03UL


### PR DESCRIPTION
Xcode 16 seems more restrictive with respect to certain types that are not included by default.
This PR fixes build for Xcode 16 by including `<sys/types.h>` when building WireGuardKitC

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/20)
<!-- Reviewable:end -->
