### PR TITLE
Disable NAT64 for exit relays when multihop is enabled

### DIFF
--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -458,11 +458,12 @@ public class WireGuardAdapter {
         var entry: DeviceConfiguration? = nil
         if let entryConfiguration {
             let resolvedEntryEndpoints = try self.resolvePeers(for: entryConfiguration)
-            entry = DeviceConfiguration(configuration: entryConfiguration, resolvedEndpoints: resolvedEntryEndpoints)
+            entry = DeviceConfiguration(configuration: entryConfiguration, resolvedEndpoints: resolvedEntryEndpoints, reResolveEndpoint: true)
         }
         
+        // Disable NAT64 resolution for exit relays when multihop is enabled
         return PacketTunnelSettingsGenerator(
-            exit: DeviceConfiguration(configuration: exitConfiguration, resolvedEndpoints: resolvedExitEndpoints),
+            exit: DeviceConfiguration(configuration: exitConfiguration, resolvedEndpoints: resolvedExitEndpoints, reResolveEndpoint: entry == nil),
             entry: entry,
             daita: daita
         )


### PR DESCRIPTION
This PR adds a new flag to `DeviceConfiguration` that, when set to `true` will disable IP re-resolution.
It's automatically set to `true` for the exit configurations when running in multihop mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/22)
<!-- Reviewable:end -->
