### PR TITLE
Use the correct relay settings when configuring DAITA

### DIFF
--- a/Sources/WireGuardKitGo/api-apple.go
+++ b/Sources/WireGuardKitGo/api-apple.go
@@ -182,7 +182,6 @@ func wgTurnOnMultihopInner(tun tun.Device, exitSettings *C.char, entrySettings *
 	wrapper := NewRouter(tun, vtun)
 	exitDev := device.NewDevice(&wrapper, singletun.Binder(), logger)
 
-	// refactoring unrolled for better mergeability, until the dust settles
 	return addTunnelFromDevice(exitDev, entryDev, exitConfigString, entryConfigString, virtualNet, logger, maybeNotMachines, maybeNotMaxEvents, maybeNotMaxActions)
 }
 
@@ -193,7 +192,6 @@ func wgTurnOnMultihop(exitSettings *C.char, entrySettings *C.char, privateIp *C.
 		Errorf:   CLogger(1).Printf,
 	}
 
-	// refactoring unrolled for better mergeability, until the dust settles
 	tun, errCode := openTUNFromSocket(tunFd, logger)
 	if tun == nil {
 		return errCode
@@ -214,7 +212,7 @@ func wgTurnOn(settings *C.char, tunFd int32, maybeNotMachines *C.char, maybeNotM
 		Verbosef: CLogger(0).Printf,
 		Errorf:   CLogger(1).Printf,
 	}
-	// refactoring unrolled for better mergeability, until the dust settles
+
 	tun, errCode := openTUNFromSocket(tunFd, logger)
 	if tun == nil {
 		return errCode


### PR DESCRIPTION
This PR fixes a somewhat messy refactoring that introduced a bug in the code that brings up wireguard devices. The refacotring unified the boilerplate code between `wgTurnOn` and `wgTurnOnMultihop`, but it ended up only being suitable for multihop. This is now remedied. I have also further removed some leftover comments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/28)
<!-- Reviewable:end -->
