### PR TITLE
Separate reads from writes to ICMP socket

### DIFF
--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -31,7 +31,7 @@ public enum WireGuardAdapterError: Error {
 
     /// The tunnel descriptor provided does not refer to an open tunnel
     case noSuchTunnel
-    
+
     /// the tunnel exists, but does not have a virtual interface
     case noTunnelVirtualInterface
 
@@ -84,6 +84,9 @@ public class WireGuardAdapter {
     /// Whether adapter should automatically raise the `reasserting` flag when updating
     /// tunnel configuration.
     private let shouldHandleReasserting: Bool
+
+    /// ID to use for ICMP echo requests. Should be reset for every tunnel connection.
+    private var pingId: UInt16 = UInt16.random(in: UInt16.min...UInt16.max)
 
     /// Tunnel device file descriptor.
     private var tunnelFileDescriptor: Int32? {
@@ -201,14 +204,14 @@ public class WireGuardAdapter {
             }
         }
     }
-    
+
     public func startMultihop(exitConfiguration: TunnelConfiguration, entryConfiguration: TunnelConfiguration?, daita: DaitaConfiguration? = nil, completionHandler: @escaping (WireGuardAdapterError?) -> Void) {
         workQueue.async {
             guard case .stopped = self.state else {
                 completionHandler(.invalidState)
                 return
             }
-            
+
             guard let privateAddress = exitConfiguration.interface.addresses.compactMap({ $0.address as? IPv4Address }).first else
             {
                 self.logHandler(.error, "WireGuardAdapter.start: No private IPv4 address found")
@@ -239,7 +242,7 @@ public class WireGuardAdapter {
                 fatalError()
             }
         }
-    
+
     }
 
     /// Start the tunnel tunnel.
@@ -456,6 +459,7 @@ public class WireGuardAdapter {
         if handle < 0 {
             throw WireGuardAdapterError.startWireGuardBackend(handle)
         }
+        pingId = UInt16.random(in: UInt16.min...UInt16.max)
         #if os(iOS)
         wgDisableSomeRoamingForBrokenMobileSemantics(handle)
         #endif
@@ -470,13 +474,13 @@ public class WireGuardAdapter {
     /// - Returns: an instance of type `PacketTunnelSettingsGenerator`.
     private func makeSettingsGenerator(with exitConfiguration: TunnelConfiguration, entryConfiguration: TunnelConfiguration? = nil, daita: DaitaConfiguration? = nil) throws -> PacketTunnelSettingsGenerator {
         let resolvedExitEndpoints = try self.resolvePeers(for: exitConfiguration)
-        
+
         var entry: DeviceConfiguration? = nil
         if let entryConfiguration {
             let resolvedEntryEndpoints = try self.resolvePeers(for: entryConfiguration)
             entry = DeviceConfiguration(configuration: entryConfiguration, resolvedEndpoints: resolvedEntryEndpoints, reResolveEndpoint: true)
         }
-        
+
         // Disable NAT64 resolution for exit relays when multihop is enabled
         return PacketTunnelSettingsGenerator(
             exit: DeviceConfiguration(configuration: exitConfiguration, resolvedEndpoints: resolvedExitEndpoints, reResolveEndpoint: entry == nil),
@@ -561,7 +565,7 @@ public class WireGuardAdapter {
             guard isSatisfiable else { return }
 
             self.logHandler(.verbose, "Connectivity online, resuming backend.")
-            
+
             guard let privateAddress = settingsGenerator.exit.configuration.interface.addresses.compactMap({ $0.address as? IPv4Address }).first else
             {
                 self.logHandler(.error, "WireGuardAdapter.start: No private IPv4 address found")
@@ -599,7 +603,8 @@ public protocol ICMPPingProvider {
 
     func closeICMP()
 
-    @discardableResult func sendICMPPing(seqNumber: UInt16) throws -> Int32
+    @discardableResult func sendICMPPing(seqNumber: UInt16) throws
+    func receiveICMP() throws -> Int32
 }
 
 extension WireGuardAdapter: ICMPPingProvider {
@@ -629,18 +634,37 @@ extension WireGuardAdapter: ICMPPingProvider {
         }
     }
 
-    @discardableResult public func sendICMPPing(seqNumber: UInt16) throws -> Int32 {
+    // Returns the sequence number of the ICMP message that was received.
+    // This could be improved by also returning the ID of the message that was received.
+    public func receiveICMP() throws -> Int32 {
         guard case .started(let tunnelHandle, _) = self.state, let icmpSocketHandle else {
             throw WireGuardAdapterError.icmpSocketNotOpen
         }
-        let seq = wgSendAndAwaitInTunnelPing(tunnelHandle, icmpSocketHandle, seqNumber)
-        if seq >= 0 { return seq }
-        switch seq {
-        case -14: // errICMPOpenSocket
+        let result = wgRecvInTunnelPing(tunnelHandle, icmpSocketHandle)
+        if result < 0 {
+            try Self.throwError(result: result)
+        }
+
+        return result
+    }
+
+    public func sendICMPPing(seqNumber: UInt16) throws {
+        guard case .started(let tunnelHandle, _) = self.state, let icmpSocketHandle else {
+            throw WireGuardAdapterError.icmpSocketNotOpen
+        }
+        let seq = wgSendInTunnelPing(tunnelHandle, icmpSocketHandle, pingId, 16, seqNumber)
+        if seq < 0 { try Self.throwError(result: seq) }
+        return
+    }
+
+    private static func throwError(result: Int32) throws {
+         switch result {
+            case -14: // errICMPOpenSocket
             throw WireGuardAdapterError.icmpSocketNotOpen
             // TODO: more fine-grained errors
-            default: throw WireGuardAdapterError.internalError(seq)
+            default: throw WireGuardAdapterError.internalError(result)
         }
+
     }
 }
 

--- a/Sources/WireGuardKitGo/api-apple.go
+++ b/Sources/WireGuardKitGo/api-apple.go
@@ -97,7 +97,7 @@ type tunnelHandle struct {
 
 type icmpHandle struct {
 	tunnelHandle int32
-	icmpSocket   *net.Conn
+	icmpSocket   net.Conn
 }
 
 var tunnelHandles = make(map[int32]tunnelHandle)

--- a/Sources/WireGuardKitGo/ian_tunnel_test.go
+++ b/Sources/WireGuardKitGo/ian_tunnel_test.go
@@ -30,7 +30,18 @@ func TestPing(t *testing.T) {
 
 	pinger := wgOpenInTunnelICMP(tunnel, cstring("1.2.3.5"))
 
-	result := wgSendAndAwaitInTunnelPing(tunnel, pinger, 1)
+	pingResultChan := make(chan int32)
+	go func() {
+		result := wgRecvInTunnelPing(tunnel, pinger)
+		pingResultChan <- result
+	}()
+
+	result := wgSendInTunnelPing(tunnel, pinger,  123, 24, 1)
+	if result < 0 {
+		t.Fatalf("Failed to send in tunnel ping")
+	}
+
+	result = <- pingResultChan
 
 	assert.Equal(t, result, int32(1))
 

--- a/Sources/WireGuardKitGo/in-tunnel-icmp.go
+++ b/Sources/WireGuardKitGo/in-tunnel-icmp.go
@@ -3,9 +3,7 @@ package main
 import "C"
 
 import (
-	"bytes"
 	"net"
-	"time"
 
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
@@ -22,7 +20,7 @@ func wgOpenInTunnelICMP(tunnelHandle int32, address *C.char) int32 {
 	}
 	conn, _ := handle.virtualNet.Dial("ping4", C.GoString(address))
 
-	result := insertHandle(icmpHandles, icmpHandle{tunnelHandle, &conn})
+	result := insertHandle(icmpHandles, icmpHandle{tunnelHandle, conn})
 	if result < 0 {
 		conn.Close()
 	}
@@ -33,16 +31,16 @@ func wgOpenInTunnelICMP(tunnelHandle int32, address *C.char) int32 {
 func wgCloseInTunnelICMP(socketHandle int32) bool {
 	socket, ok := icmpHandles[socketHandle]
 	if ok {
-		(*(socket.icmpSocket)).Close()
+		socket.icmpSocket.Close()
 		delete(icmpHandles, socketHandle)
 	}
 	return ok
 }
 
 // returns the sequence number or an error code
-func parsePingResponse(socket *net.Conn, pingdata []byte) int {
+func parsePingResponse(socket net.Conn) int32 {
 	readBuff := make([]byte, 1024)
-	readBytes, err := (*(socket)).Read(readBuff)
+	readBytes, err := socket.Read(readBuff)
 	if readBytes <= 0 || err != nil {
 		return errICMPReadSocket
 	}
@@ -54,63 +52,59 @@ func parsePingResponse(socket *net.Conn, pingdata []byte) int {
 	if !ok {
 		return errICMPResponseFormat
 	}
-	if !bytes.Equal(replyPing.Data, pingdata) {
-		return errICMPResponseContent
-	}
-	return replyPing.Seq
+	return int32(replyPing.Seq)
 }
 
-// this returns the sequence number or a negative value if an error occurred
+// This function blocks until the ICMP socket is closed or an ICMP echo-response is received.
+//export wgRecvInTunnelPing
+func wgRecvInTunnelPing(tunnelHandel int32, socketHandle int32) int32 {
+	handle, ok := icmpHandles[socketHandle]
+	if !ok {
+		return errICMPOpenSocket
+	}
+
+	for {
+		// Receive ICMP packets until an echo-response is received
+		result := recvInTunnelPing(handle.icmpSocket)
+		// Only break the loop if the error has nothing to do with the ICMP response format.
+		// It should ignore malformed responses and non-echo-responses.
+		if result != errICMPResponseFormat {
+			return result
+		}
+	}
+}
+
+func recvInTunnelPing(ping net.Conn) int32 {
+	return parsePingResponse(ping)
+}
+
+// This function returns a negative value if an error occurred. Otherwise, it returns 0.
+// This function can be called concurrently.
 //
-//export wgSendAndAwaitInTunnelPing
-func wgSendAndAwaitInTunnelPing(tunnelHandle int32, socketHandle int32, sequenceNumber uint16) int32 {
+//export wgSendInTunnelPing
+func wgSendInTunnelPing(tunnelHandle int32, socketHandle int32, pingId uint16, pingSize int, sequenceNumber uint16) int32 {
 	socket, ok := icmpHandles[socketHandle]
 	if !ok {
 		return errICMPOpenSocket
 	}
-	dataLength := 16
-	pingdata := make([]byte, dataLength)
+	pingdata := make([]byte, pingSize)
 	_, err := rng.Read(pingdata)
-	pingid := rng.Int()
 
-	resultChannel := make(chan int)
-	shutdownChannel := make(chan struct{})
-
-	// the reading goroutine
-	go func() {
-		for {
-			select {
-			case <-shutdownChannel:
-				return
-			default:
-			}
-			result := parsePingResponse(socket.icmpSocket, pingdata)
-			if result == errICMPResponseContent || result >= 0 {
-				resultChannel <- result
-				return
-			}
-		}
-	}()
-
-	// probably not worth checking for an error here
 	ping := icmp.Message{
 		Type: ipv4.ICMPTypeEcho,
 		Body: &icmp.Echo{
-			ID:   pingid,
+			ID:   int(pingId),
 			Seq:  int(sequenceNumber),
 			Data: pingdata,
 		},
 	}
 	pingBytes, err := ping.Marshal(nil)
-	_, err = (*(socket.icmpSocket)).Write(pingBytes)
 	if err != nil {
 		return errICMPWriteSocket
 	}
-	defer close(shutdownChannel)
-	select {
-	case result := <-resultChannel:
-		return int32(result)
-	case <-time.After(10 * time.Second):
-		return errICMPTimeout
+	_, err = socket.icmpSocket.Write(pingBytes)
+	if err != nil {
+		return errICMPWriteSocket
 	}
+	return 0
 }

--- a/Sources/WireGuardKitGo/in-tunnel-icmp_test.go
+++ b/Sources/WireGuardKitGo/in-tunnel-icmp_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"net/netip"
+	"time"
+
+	"testing"
+
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+// Verify that closing a socket will terminate any in-flight reads.
+func TestIcmpSocketCloseTerminatesRead(t *testing.T) {
+	_, virtualNet, err := netstack.CreateNetTUN([]netip.Addr{netip.MustParseAddr("1.2.3.3")}, []netip.Addr{}, 1280)
+	if err != nil {
+		t.Fatalf("Failed to initialize ")
+	}
+	conn, _ := virtualNet.Dial("ping4", "1.2.3.4")
+	closeChan := make(chan int32)
+	go func() {
+		err := recvInTunnelPing(conn)
+		closeChan <- err
+	}()
+	// the sleep is a horrible hack to try and ensure the read is actually in flight
+	time.Sleep(time.Second * 1)
+	conn.Close()
+
+	closeResult := <-closeChan
+	if closeResult != errICMPReadSocket {
+		t.Fatalf("Expected the ICMP socket read to fail with error %d , thus expected a negative erorr code, instead got %d", errICMPReadSocket, closeResult)
+	}
+}
+
+// Verify that closing a socket will fail any subsequent reads.
+func TestIcmpSocketCloseFailsReadImmediately(t *testing.T) {
+	_, virtualNet, err := netstack.CreateNetTUN([]netip.Addr{netip.MustParseAddr("1.2.3.3")}, []netip.Addr{}, 1280)
+	if err != nil {
+		t.Fatalf("Failed to initialize ")
+	}
+	conn, _ := virtualNet.Dial("ping4", "1.2.3.4")
+	conn.Close()
+	recvResult := recvInTunnelPing(conn)
+
+	if recvResult >= 0 {
+		t.Fatalf("Expected the ICMP socket read to fail with an error, thus expected a negative erorr code, instead got %d", err)
+	}
+}

--- a/Sources/WireGuardKitGo/wireguard.h
+++ b/Sources/WireGuardKitGo/wireguard.h
@@ -22,7 +22,8 @@ extern void wgBumpSockets(int handle);
 extern void wgDisableSomeRoamingForBrokenMobileSemantics(int handle);
 extern int wgOpenInTunnelICMP(int tunnelHandle, const char *address);
 extern int wgCloseInTunnelICMP(int socketHandle);
-extern int wgSendAndAwaitInTunnelPing(int tunnelHandle, int socketHandle, uint16_t sequenceNumber);
+extern int32_t wgSendInTunnelPing(int tunnelHandle, int socketHandle, uint16_t pingId, int pingSize, uint16_t sequenceNumber);
+extern int32_t wgRecvInTunnelPing(int tunnelHandle, int socketHandle);
 extern const char *wgVersion();
 
 #endif


### PR DESCRIPTION
Previously, the function sending ICMP echo requests wouldn't return until it received a well formed echo reply to that specific request. With these changes, a separate Go function for receiving ICMP ehco replies in a blocking fashion is added, to allow the pinger to send multiple ICMP requests without waiting for responses. I've added some tests to verify that the blocking calls do return once the ICMP socket is closed. Further, `WireGuardAdapter` has been changed to use these new functions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/29)
<!-- Reviewable:end -->
