### PR TITLE
Fix race conditions in pinger

### DIFF
--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -234,8 +234,9 @@ public class WireGuardAdapter {
                     settingsGenerator
                 )
 
-                let gatewayAddress = IPv4Address("10.64.0.1")!
-                try self.openICMP(address: gatewayAddress)
+                if let gateway = exitConfiguration.pingableGateway {
+                    try self.openICMP(address: gateway)
+                }
 
                 completionHandler(nil)
             } catch let error as WireGuardAdapterError {
@@ -338,8 +339,9 @@ public class WireGuardAdapter {
                 self.state = .started(handle, settingsGenerator)
 
                 do {
-                    let gatewayAddress = IPv4Address("10.64.0.1")!
-                    try self.openICMP(address: gatewayAddress)
+                    if let gateway = tunnelConfiguration.pingableGateway {
+                        try self.openICMP(address: gateway)
+                    }
                 } catch let error as WireGuardAdapterError {
                     completionHandler(error)
                     return
@@ -599,8 +601,9 @@ public class WireGuardAdapter {
                     settingsGenerator
                 )
 
-                let gatewayAddress = IPv4Address("10.64.0.1")!
-                try self.openICMP(address: gatewayAddress)
+                if let gatewayAddress = settingsGenerator.exit.configuration.pingableGateway {
+                    try self.openICMP(address: gatewayAddress)
+                }
             } catch {
                 self.logHandler(.error, "Failed to restart backend: \(error.localizedDescription)")
             }
@@ -662,9 +665,9 @@ extension WireGuardAdapter: ICMPPingProvider {
             guard case .started(let tunnelHandle, _) = self.state, let icmpSocketHandle else {
                 throw WireGuardAdapterError.icmpSocketNotOpen
             }
-            return (tunnelHandle, icmpSocketHandle)
+            return (tunnelHandle: tunnelHandle, socketHandle: icmpSocketHandle)
         }
-        let result = wgRecvInTunnelPing(tunnelSocketPair.0, tunnelSocketPair.1)
+        let result = wgRecvInTunnelPing(tunnelSocketPair.tunnelHandle, tunnelSocketPair.socketHandle)
         if result < 0 {
             try Self.throwError(result: result)
         }
@@ -678,9 +681,9 @@ extension WireGuardAdapter: ICMPPingProvider {
             guard case .started(let tunnelHandle, _) = self.state, let icmpSocketHandle else {
                 throw WireGuardAdapterError.icmpSocketNotOpen
             }
-            return (tunnelHandle, icmpSocketHandle)
+            return (tunnelHandle: tunnelHandle, socketHandle: icmpSocketHandle)
         }
-        let seq = wgSendInTunnelPing(tunnelSocketPair.0, tunnelSocketPair.1, pingId, 16, seqNumber)
+        let seq = wgSendInTunnelPing(tunnelSocketPair.tunnelHandle, tunnelSocketPair.socketHandle, pingId, 16, seqNumber)
         if seq < 0 { try Self.throwError(result: seq) }
     }
 

--- a/Sources/WireGuardKitGo/in-tunnel-icmp.go
+++ b/Sources/WireGuardKitGo/in-tunnel-icmp.go
@@ -18,7 +18,10 @@ func wgOpenInTunnelICMP(tunnelHandle int32, address *C.char) int32 {
 	if handle.virtualNet == nil {
 		return errNoTunnelVirtualInterface
 	}
-	conn, _ := handle.virtualNet.Dial("ping4", C.GoString(address))
+	conn, err := handle.virtualNet.Dial("ping4", C.GoString(address))
+	if err != nil {
+		return errICMPOpenSocket
+	}
 
 	result := insertHandle(icmpHandles, icmpHandle{tunnelHandle, conn})
 	if result < 0 {

--- a/Sources/WireGuardKitTypes/TunnelConfiguration.swift
+++ b/Sources/WireGuardKitTypes/TunnelConfiguration.swift
@@ -2,16 +2,19 @@
 // Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
 
 import Foundation
+import Network
 
 public final class TunnelConfiguration {
     public var name: String?
     public var interface: InterfaceConfiguration
     public let peers: [PeerConfiguration]
+    public let pingableGateway: IPv4Address?
 
-    public init(name: String?, interface: InterfaceConfiguration, peers: [PeerConfiguration]) {
+    public init(name: String?, interface: InterfaceConfiguration, peers: [PeerConfiguration], pingableGateway: IPv4Address? = nil) {
         self.interface = interface
         self.peers = peers
         self.name = name
+        self.pingableGateway = pingableGateway
 
         let peerPublicKeysArray = peers.map { $0.publicKey }
         let peerPublicKeysSet = Set<PublicKey>(peerPublicKeysArray)


### PR DESCRIPTION
This PR fixes a race condition in accessing the WireguardAdapter when sending and receiving pings.
It also changes the ability to open and close the socket used for pinging from `public` to `private`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/31)
<!-- Reviewable:end -->
