### PR TITLE
Make getRuntimeConfiguration not asynchronous

### DIFF
--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -195,18 +195,18 @@ public class WireGuardAdapter {
 
     /// Returns a runtime configuration from WireGuard.
     /// - Parameter completionHandler: completion handler.
-    public func getRuntimeConfiguration(completionHandler: @escaping (String?) -> Void) {
-        workQueue.async {
+    public func getRuntimeConfiguration() -> String? {
+        dispatchPrecondition(condition: .notOnQueue(workQueue))
+        return workQueue.sync {
             guard case .started(let handle, _) = self.state else {
-                completionHandler(nil)
-                return
+                return nil
             }
-
             if let settings = wgGetConfig(handle) {
-                completionHandler(String(cString: settings))
+                let settingsString = String(cString: settings)
                 free(settings)
+                return settingsString
             } else {
-                completionHandler(nil)
+                return nil
             }
         }
     }

--- a/Sources/WireGuardNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/WireGuardNetworkExtension/PacketTunnelProvider.swift
@@ -95,11 +95,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         guard let completionHandler = completionHandler else { return }
 
         if messageData.count == 1 && messageData[0] == 0 {
-            adapter.getRuntimeConfiguration { settings in
+            if let settings = adapter.getRuntimeConfiguration() {
                 var data: Data?
-                if let settings = settings {
                     data = settings.data(using: .utf8)!
-                }
                 completionHandler(data)
             }
         } else {


### PR DESCRIPTION
This PR makes the `getRuntimeConfiguration` synchronous since it's guaranteed to return immediately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/36)
<!-- Reviewable:end -->
