### PR TITLE
Pre-chunk TCP payloads

### DIFF
--- a/Sources/WireGuardKitGo/in-tunnel-tcp.go
+++ b/Sources/WireGuardKitGo/in-tunnel-tcp.go
@@ -53,6 +53,26 @@ func wgCloseInTunnelTCP(tunnelHandle int32, socketHandle int32) bool {
 	return tun.RemoveAndCloseSocket(socketHandle)
 }
 
+// chunkIterator returns a closure that returns successive chunks of the given
+// slice. Each call to the returned function returns the next chunk of size
+// chunkSize. The last chunk will have a size between 1 and maximum chunk size.
+// When no more data remains, the closure returns nil.
+func chunkIterator(data []byte, chunkSize int) func() []byte {
+	offset := 0
+	return func() []byte {
+		if offset >= len(data) {
+			return nil
+		}
+		end := offset + chunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[offset:end]
+		offset = end
+		return chunk
+	}
+}
+
 // Sends the data array into the TCP socket in a blocking fashion. The data
 // pointer should point to at least `dataLen` bytes for the entirety of this
 // call. This function is technically threadsafe, but multiple calls will not
@@ -75,17 +95,26 @@ func wgSendInTunnelTCP(tunnelHandle int32, socketHandle int32, data *byte, dataL
 		return errTCPNoSocket
 	}
 
-	n, err := socket.Write(unsafe.Slice(data, dataLen))
-	if err != nil {
-		tun.logger.Errorf("Failed to write to TCP connection: %v", err)
-		return errTCPWrite
+	originalBuffer := unsafe.Slice(data, dataLen)
+	totalBytesWritten := 0
+
+	nextChunk := chunkIterator(originalBuffer, 1000)
+	for chunk := nextChunk(); chunk != nil; chunk = nextChunk() {
+		n, err := socket.Write(chunk)
+		if err != nil {
+			tun.logger.Errorf("TCP Failed to write to TCP connection: %v", err)
+			return errTCPWrite
+		}
+
+		totalBytesWritten += n
 	}
-	if n != int(dataLen) {
-		tun.logger.Errorf("Expected to write %v bytes, instead wrote %v", err)
+
+	if totalBytesWritten != int(dataLen) {
+		tun.logger.Errorf("TCP Expected to write %v bytes, instead wrote %v", dataLen, totalBytesWritten)
 		return errTCPWrite
 	}
 
-	return int32(n)
+	return int32(totalBytesWritten)
 }
 
 // Blocking call to receive bytes into the buffer from a TCP connection. The

--- a/Sources/WireGuardKitGo/in-tunnel-tcp_test.go
+++ b/Sources/WireGuardKitGo/in-tunnel-tcp_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/netip"
+	"reflect"
 	"testing"
 	"unsafe"
 
@@ -115,4 +116,80 @@ func TestInTunnelTCPShutdown(t *testing.T) {
 	}
 
 	wgTurnOff(tunnel)
+}
+
+func TestChunkIterator_EmptySlice(t *testing.T) {
+	data := []byte{}
+	nextChunk := chunkIterator(data, 10)
+
+	chunk := nextChunk()
+	if chunk != nil {
+		t.Errorf("Expected nil for empty slice, got %v", chunk)
+	}
+}
+
+func TestChunkIterator_MultipleChunks(t *testing.T) {
+	data := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	nextChunk := chunkIterator(data, 3)
+
+	// First chunk
+	chunk := nextChunk()
+	expected := []byte{1, 2, 3}
+	if !reflect.DeepEqual(chunk, expected) {
+		t.Errorf("Chunk 1: Expected %v, got %v", expected, chunk)
+	}
+
+	// Second chunk
+	chunk = nextChunk()
+	expected = []byte{4, 5, 6}
+	if !reflect.DeepEqual(chunk, expected) {
+		t.Errorf("Chunk 2: Expected %v, got %v", expected, chunk)
+	}
+
+	// Third chunk
+	chunk = nextChunk()
+	expected = []byte{7, 8, 9}
+	if !reflect.DeepEqual(chunk, expected) {
+		t.Errorf("Chunk 3: Expected %v, got %v", expected, chunk)
+	}
+
+	// Fourth chunk (partial)
+	chunk = nextChunk()
+	expected = []byte{10}
+	if !reflect.DeepEqual(chunk, expected) {
+		t.Errorf("Chunk 4: Expected %v, got %v", expected, chunk)
+	}
+
+	// No more chunks
+	chunk = nextChunk()
+	if chunk != nil {
+		t.Errorf("Expected nil after exhausting chunks, got %v", chunk)
+	}
+}
+
+
+func TestChunkIterator_SliceValidity(t *testing.T) {
+	// Test that returned slices are valid views into the original data
+	data := []byte{1, 2, 3, 4, 5, 6}
+	nextChunk := chunkIterator(data, 2)
+
+	chunk1 := nextChunk()
+	chunk2 := nextChunk()
+	chunk3 := nextChunk()
+
+	// Modify the original data
+	data[1] = 99
+	data[3] = 88
+	data[5] = 77
+
+	// Chunks should reflect the changes (they're slices of the original)
+	if chunk1[1] != 99 {
+		t.Errorf("Expected chunk1[1] to be 99, got %d", chunk1[1])
+	}
+	if chunk2[1] != 88 {
+		t.Errorf("Expected chunk2[1] to be 88, got %d", chunk2[1])
+	}
+	if chunk3[1] != 77 {
+		t.Errorf("Expected chunk3[1] to be 77, got %d", chunk3[1])
+	}
 }


### PR DESCRIPTION
We do not know why, but the TCP connection used by the ephemeral peer negotiation ends up being _wonky_ when done over an LWO connection. It seems to work better when we _chunk_ the TCP transfers to ~1000 bytes. In staging.

This is not an issue in any other case. Specifically, the app works great:
* in production
* with production canaries that have the same software deployed from staging
* using ephemeral peers with any other form of obfuscation
* using LWO without ephemeral peers

In all ephemeral peer negotiation cases, the TCP connection works except when done over LWO in staging. But we're adding this workaround because it unblocks LWO, and it seems to _just work_. 

The changes here feel extra futile since the TCP networking stack is being given an MTU already so it should segment the payload into packets by default anyway. I tried just adjusting the MTUs to lower values _every which where_, but it did not yield any results. Worse still, if one was to wait long enough, the client may connect to a staging relay with EP/LWO anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-apple/40)
<!-- Reviewable:end -->
